### PR TITLE
Add lib/process-files; refactor dotfiles, user-bin; add diff

### DIFF
--- a/scripts/diff
+++ b/scripts/diff
@@ -1,0 +1,33 @@
+#! /usr/bin/env bash
+#
+# Opens vimdiff on files that differ
+#
+# The installed file will be on the left, and the repo file on the right.
+
+export DIFF_EDITOR="${DIFF_EDITOR:-vimdiff}"
+
+. "$_GO_USE_MODULES" 'log' 'process-files'
+
+_diff_edit_if_different() {
+  if [[ ! -f "$1" ]]; then
+    @go.log WARN "$1" does not exist
+  elif ! diff "$1" "$2" >/dev/null; then
+    @go.log INFO Diffing "$1" against "$2"
+    "$DIFF_EDITOR" "$1" "$2"
+  fi
+}
+
+_diff_dotfile() {
+  _diff_edit_if_different "$HOME/${1#dotfiles/}" "$1"
+}
+
+_diff_user_bin_script() {
+  _diff_edit_if_different "$HOME/bin/${1#user-bin/*/}" "$1"
+}
+
+_diff() {
+  process_dotfiles _diff_dotfile
+  process_user_bin_scripts _diff_user_bin_script
+}
+
+_diff "$@"

--- a/scripts/install.d/dotfiles
+++ b/scripts/install.d/dotfiles
@@ -26,14 +26,17 @@ _dotfiles_add_source_bash_dev() {
   fi
 }
 
+_dotfiles_copy_to_user_home_dir() {
+  copy_file_safely "$1" 'dotfiles/' "$HOME"
+}
+
 _dotfiles() {
+  local dotfiles
   local dotfile
 
   @go.log INFO Copying dotfiles into "$HOME"
-
-  while IFS= read -r dotfile; do
-    copy_file_safely "$dotfile" 'dotfiles/' "$HOME"
-  done < <(find dotfiles -type f)
+  . "$_GO_USE_MODULES" 'process-files'
+  process_dotfiles _dotfiles_copy_to_user_home_dir
   _dotfiles_add_source_bash_dev
 }
 

--- a/scripts/install.d/user-bin
+++ b/scripts/install.d/user-bin
@@ -6,16 +6,16 @@
 
 . "$_GO_USE_MODULES" 'platform' 'copy'
 
+install_user_bin_scripts_do_copy() {
+  copy_file_safely "$1" "${1%/*}/" "$HOME/bin" '700' '700'
+}
+
 install_user_bin_scripts() {
   local script
 
   @go.log INFO Copying user-bin scripts into "$HOME/bin"
-
-  for script in user-bin/{common,$PLATFORM_ID}/*; do
-    if [[ -f "$script" ]]; then
-      copy_file_safely "$script" "${script%/*}/" "$HOME/bin" '700' '700'
-    fi
-  done
+  . "$_GO_USE_MODULES" 'process-files'
+  process_user_bin_scripts install_user_bin_scripts_do_copy
 }
 
 install_user_bin_scripts "$@"

--- a/scripts/lib/process-files
+++ b/scripts/lib/process-files
@@ -1,0 +1,48 @@
+#! /usr/bin/env bash
+#
+# Functions for processing lists of dev setup files
+#
+# Exports:
+#   process_files
+#     Perform an operation on each path that is a regular file
+#
+#   process_dotfiles
+#     Perform an operation on each dotfile path
+#
+#   process_user_bin_scripts
+#     Perform an operation on all user-bin script paths
+
+# Perform an operation on each path that is a regular file
+#
+# Arguments:
+#   operation:  Name of the function taking a file path as an argument
+#   ${@:1}:     List of paths to begin examining
+process_files() {
+  local f
+  for f in "${@:1}"; do
+    if [[ -f "$f" ]]; then
+      "$1" "$f"
+    elif [[ -d "$f" ]]; then
+      process_files "$1" "$f"/*
+    fi
+  done
+}
+
+# Perform an operation on each dotfile path
+#
+# Arguments:
+#   operation:  Function taking a dotfile path as an argument
+process_dotfiles() {
+  process_files "$1" dotfiles/.[A-Za-z0-9_-]*
+}
+
+# Perform an operation on all user-bin script paths
+#
+# Arguments:
+#   operation:  Function taking a user-bin script path as an argument
+process_user_bin_scripts() {
+  if [[ -z "$PLATFORM_ID" ]]; then
+    . "$_GO_USE_MODULES" 'platform'
+  fi
+  process_files "$1" user-bin/{common,$PLATFORM_ID}/*
+}


### PR DESCRIPTION
The `process_files` functional abstraction makes it easy to process files in a uniform way without `for` or `while` loops or external programs like `find`. I'll probably move it into go-script-bash eventually, along with a similar `process_dirs` and `process_all`.

The `diff` command allows me to see how I've modified dotfiles either on the host or in the repo, and consider porting the changes one way or the other.