### PR TITLE
Rename lib/process-files to lib/walk; add apps-home

### DIFF
--- a/dotfiles/.bash_dev
+++ b/dotfiles/.bash_dev
@@ -4,7 +4,9 @@ umask 022
 APPS_HOME="/usr/local/mbland"
 
 for script in "$APPS_HOME"/etc/profile.d/*; do
-  . "$script"
+  if [[ -f "$script" ]]; then
+    . "$script"
+  fi
 done
 
 PS1="\[\033[01;32m\]\u@\h \[\033[00m\]\[\033[01;34m\]\w\$\[\033[00m\] "

--- a/scripts/diff
+++ b/scripts/diff
@@ -6,7 +6,7 @@
 
 export DIFF_EDITOR="${DIFF_EDITOR:-vimdiff}"
 
-. "$_GO_USE_MODULES" 'log' 'process-files'
+. "$_GO_USE_MODULES" 'log' 'walk'
 
 _diff_edit_if_different() {
   if [[ ! -f "$1" ]]; then
@@ -26,8 +26,8 @@ _diff_user_bin_script() {
 }
 
 _diff() {
-  process_dotfiles _diff_dotfile
-  process_user_bin_scripts _diff_user_bin_script
+  walk_dotfiles _diff_dotfile
+  walk_user_bin_scripts _diff_user_bin_script
 }
 
 _diff "$@"

--- a/scripts/install.d/dotfiles
+++ b/scripts/install.d/dotfiles
@@ -2,7 +2,7 @@
 #
 # Installs dotfiles in the user's `HOME` directory
 
-. "$_GO_USE_MODULES" 'copy'
+. "$_GO_USE_MODULES" 'copy' 'walk'
 
 _dotfiles_add_source_bash_dev() {
   local candidates=(
@@ -35,8 +35,7 @@ _dotfiles() {
   local dotfile
 
   @go.log INFO Copying dotfiles into "$HOME"
-  . "$_GO_USE_MODULES" 'process-files'
-  process_dotfiles _dotfiles_copy_to_user_home_dir
+  walk_dotfiles _dotfiles_copy_to_user_home_dir
   _dotfiles_add_source_bash_dev
 }
 

--- a/scripts/install.d/languages
+++ b/scripts/install.d/languages
@@ -14,23 +14,10 @@
 #   RUBY_VERSION:    Version of Ruby to install
 #   RBENV_VERSION:   Tag or commit hash of rbenv version to install
 
+. "$_GO_USE_MODULES" 'apps-home'
+
 _languages() {
-  local app_sys_root="$1"
-  local language
-
-  if [ ! -d $app_sys_root ]; then
-    mkdir -p $app_sys_root
-  fi
-
-  if [ ! -d /etc/profile.d ]; then
-    mkdir /etc/profile.d
-    cat >>/etc/profile <<'END_PROFILE'
-for script in /etc/profile.d/*.sh
-do
-  . $script
-done
-END_PROFILE
-  fi
+  create_apps_home
 
   @go install languages "go" "$GO_VERSION" "$GVM_VERSION"
   @go install languages "node" "$NODEJS_VERSION" "$NVM_VERSION"

--- a/scripts/install.d/languages.d/go
+++ b/scripts/install.d/languages.d/go
@@ -11,7 +11,7 @@
 #
 # Will install gvm in `<app-sys-root>/gvm` and add `/etc/profile.d/gvm.sh`.
 
-declare -r _GVM_PROFILE='/etc/profile.d/gvm.sh'
+declare -r _GVM_PROFILE="$APPS_HOME/etc/profile.d/gvm.sh"
 declare -r _GVM_INSTALLER_URL='https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer'
 
 _install_gvm() {

--- a/scripts/install.d/user-bin
+++ b/scripts/install.d/user-bin
@@ -4,7 +4,7 @@
 #
 # These may be common or platform-specific scripts.
 
-. "$_GO_USE_MODULES" 'platform' 'copy'
+. "$_GO_USE_MODULES" 'platform' 'copy' 'walk'
 
 install_user_bin_scripts_do_copy() {
   copy_file_safely "$1" "${1%/*}/" "$HOME/bin" '700' '700'
@@ -14,8 +14,7 @@ install_user_bin_scripts() {
   local script
 
   @go.log INFO Copying user-bin scripts into "$HOME/bin"
-  . "$_GO_USE_MODULES" 'process-files'
-  process_user_bin_scripts install_user_bin_scripts_do_copy
+  walk_user_bin_scripts install_user_bin_scripts_do_copy
 }
 
 install_user_bin_scripts "$@"

--- a/scripts/lib/apps-home
+++ b/scripts/lib/apps-home
@@ -6,7 +6,7 @@
 #   create_apps_home
 #     Creates the APPS_HOME directory structure
 
-. "$_GO_USE_MODULES" 'log' 'process-files'
+. "$_GO_USE_MODULES" 'log' 'walk'
 
 export APPS_HOME_DIRS=(
   "$APPS_HOME/etc/profile.d"

--- a/scripts/lib/apps-home
+++ b/scripts/lib/apps-home
@@ -1,0 +1,28 @@
+#! /usr/bin/env bash
+#
+# Utilities to manage the APPS_HOME directory structure
+#
+# Exports:
+#   create_apps_home
+#     Creates the APPS_HOME directory structure
+
+. "$_GO_USE_MODULES" 'log' 'process-files'
+
+export APPS_HOME_DIRS=(
+  "$APPS_HOME/etc/profile.d"
+)
+export APPS_HOME_DIR_PERMISSIONS="${APPS_HOME_DIR_PERMISSIONS:-755}"
+export APPS_HOME_FILE_PERMISSIONS="${APPS_HOME_FILE_PERMISSIONS:-644}"
+
+if [[ -z "$APPS_HOME" ]]; then
+  @go.log FATAL "APPS_HOME not defined; set it in settings.bash"
+fi
+
+# Creates the APPS_HOME directory structure
+create_apps_home() {
+  local dir
+
+  for dir in "${APPS_HOME_DIRS[@]}"; do
+    create_dirs_with_permissions "$dir" "$APPS_HOME_DIR_PERMISSIONS"
+  done
+}

--- a/scripts/lib/copy
+++ b/scripts/lib/copy
@@ -6,6 +6,8 @@
 #   copy_file_safely
 #     Copy a file, creating directories if need be, only if it doesn't exist
 
+. "$_GO_USE_MODULES" 'walk'
+
 # Copy a file, creating directories if need be, only if it doesn't exist
 #
 # Arguments:
@@ -23,20 +25,8 @@ copy_file_safely() {
   local dest="$dest_dir/${src#$src_prefix}"
   local dest_parent="${dest_dir%/*}"
 
-  dest_dir="${dest%/*}"
   printf '%s => %s\n' "$src" "$dest"
-
-  if [[ ! -d "$dest_dir" ]]; then
-    if ! mkdir -p "$dest_dir"; then
-      @go.log FATAL Failed to create "$dest_dir"
-    fi
-    while [[ "$dest_dir" != "$dest_parent" ]]; do
-      if ! chmod "$dir_perms" "$dest_dir"; then
-        @go.log FATAL Failed to set permissions on "$dest_dir"
-      fi
-      dest_dir="${dest_dir%/*}"
-    done
-  fi
+  create_dirs_with_permissions "$dest_dir" "$dir_perms"
 
   if [[ ! -f "$dest" ]]; then
     if ! cp "$src" "$dest"; then

--- a/scripts/lib/process-files
+++ b/scripts/lib/process-files
@@ -11,6 +11,15 @@
 #
 #   process_user_bin_scripts
 #     Perform an operation on all user-bin script paths
+#
+#   process_path_forward
+#     Processes a file path from the first component to the last
+#
+#   create_dir_with_permissions
+#     Creates a directory with the specified permissions
+#
+#   create_dirs_with_permissions
+#     Creates a directory and its parents with the specified permissions
 
 # Perform an operation on each path that is a regular file
 #
@@ -47,4 +56,74 @@ process_user_bin_scripts() {
     . "$_GO_USE_MODULES" 'platform'
   fi
   process_files "$1" user-bin/{common,$PLATFORM_ID}/*
+}
+
+# Processes a file path from the first component to the last
+#
+# The first call to `operation` receives the first component of the path as its
+# path argument. Each successive call to `operation` receives the previous path
+# plus its child component. The processing is terminated when `operation`
+# returns a nonzero value.
+#
+# Arguments:
+#   operation:  Name of the function taking a file path as an argument
+#   ${@:1}:     List of paths to begin examining
+process_path_forward() {
+  local operation="$1"
+  local oldIFS="$IFS"
+  local IFS='/'
+  local components=($2)
+  local component
+  local current_path
+
+  IFS="$oldIFS"
+
+  for component in "${components[@]}"; do
+    current_path+="$component/"
+    if ! "$operation" "$current_path"; then
+      break
+    fi
+  done
+}
+
+# Creates a directory with the specified permissions
+#
+# If a directory already exists, this function does not update its permissions.
+#
+# Globals:
+#   permissions:  May be defined as an alternative to passing as a parameter
+#
+# Arguments:
+#   dir:          The path of the directory to create
+#   permissions:  The permissions to set on the directory, if created
+create_dir_with_permissions() {
+  local dir="$1"
+  local permissions="${2:-$permissions}"
+
+  if [[ -z "$dir" ]]; then
+    @go.log FATAL "Directory argument not specified"
+  elif [[ -z "$permissions" ]]; then
+    @go.log FATAL "Permissions not specified"
+  fi
+
+  if [[ ! -d "$dir" ]]; then
+    @go.log INFO "Creating $dir"
+
+    if ! mkdir "$dir"; then
+      @go.log FATAL "Could not create $dir"
+    elif ! chmod "$permissions" "$dir"; then
+      @go.log FATAL "Could not set permissions for $dir"
+    fi
+  fi
+}
+
+# Creates a directory and its parents with the specified permissions
+#
+# If a directory already exists, this function does not update its permissions.
+#
+# Arguments:
+#   dir:          The path of the directory to create
+#   permissions:  The permissions to set on any created directory
+create_dirs_with_permissions() {
+  permissions="$2" process_path_forward create_dir_with_permissions "$1"
 }

--- a/scripts/lib/process-files
+++ b/scripts/lib/process-files
@@ -14,14 +14,16 @@
 
 # Perform an operation on each path that is a regular file
 #
+# The recursion is terminated when `operation` returns a nonzero value.
+#
 # Arguments:
 #   operation:  Name of the function taking a file path as an argument
 #   ${@:1}:     List of paths to begin examining
 process_files() {
   local f
   for f in "${@:1}"; do
-    if [[ -f "$f" ]]; then
-      "$1" "$f"
+    if [[ -f "$f" ]] && ! "$1" "$f"; then
+      return
     elif [[ -d "$f" ]]; then
       process_files "$1" "$f"/*
     fi

--- a/scripts/lib/walk
+++ b/scripts/lib/walk
@@ -3,16 +3,16 @@
 # Functions for processing lists of dev setup files
 #
 # Exports:
-#   process_files
+#   walk_files
 #     Perform an operation on each path that is a regular file
 #
-#   process_dotfiles
+#   walk_dotfiles
 #     Perform an operation on each dotfile path
 #
-#   process_user_bin_scripts
+#   walk_user_bin_scripts
 #     Perform an operation on all user-bin script paths
 #
-#   process_path_forward
+#   walk_path_forward
 #     Processes a file path from the first component to the last
 #
 #   create_dir_with_permissions
@@ -28,13 +28,13 @@
 # Arguments:
 #   operation:  Name of the function taking a file path as an argument
 #   ${@:1}:     List of paths to begin examining
-process_files() {
+walk_files() {
   local f
   for f in "${@:1}"; do
     if [[ -f "$f" ]] && ! "$1" "$f"; then
       return
     elif [[ -d "$f" ]]; then
-      process_files "$1" "$f"/*
+      walk_files "$1" "$f"/*
     fi
   done
 }
@@ -43,19 +43,19 @@ process_files() {
 #
 # Arguments:
 #   operation:  Function taking a dotfile path as an argument
-process_dotfiles() {
-  process_files "$1" dotfiles/.[A-Za-z0-9_-]*
+walk_dotfiles() {
+  walk_files "$1" dotfiles/.[A-Za-z0-9_-]*
 }
 
 # Perform an operation on all user-bin script paths
 #
 # Arguments:
 #   operation:  Function taking a user-bin script path as an argument
-process_user_bin_scripts() {
+walk_user_bin_scripts() {
   if [[ -z "$PLATFORM_ID" ]]; then
     . "$_GO_USE_MODULES" 'platform'
   fi
-  process_files "$1" user-bin/{common,$PLATFORM_ID}/*
+  walk_files "$1" user-bin/{common,$PLATFORM_ID}/*
 }
 
 # Processes a file path from the first component to the last
@@ -68,7 +68,7 @@ process_user_bin_scripts() {
 # Arguments:
 #   operation:  Name of the function taking a file path as an argument
 #   ${@:1}:     List of paths to begin examining
-process_path_forward() {
+walk_path_forward() {
   local operation="$1"
   local oldIFS="$IFS"
   local IFS='/'
@@ -125,5 +125,5 @@ create_dir_with_permissions() {
 #   dir:          The path of the directory to create
 #   permissions:  The permissions to set on any created directory
 create_dirs_with_permissions() {
-  permissions="$2" process_path_forward create_dir_with_permissions "$1"
+  permissions="$2" walk_path_forward create_dir_with_permissions "$1"
 }

--- a/settings.bash
+++ b/settings.bash
@@ -1,5 +1,5 @@
 # Root directory for language manager installs.
-declare -r APPS_ROOT='/usr/local/mbland'
+declare -r APPS_HOME='/usr/local/mbland'
 
 # List of language for which to install language managers.
 declare -r INSTALL_LANGUAGES=('go')


### PR DESCRIPTION
This is in anticipation of moving some of these functions to go-script-bash, after realizing that `walk` is a standard (and shorter!) term for processing file and directory paths and structures. Also includes some new functions to support the new `apps-home` module.

Also contains a tweak to `.bash_dev` to ensure each `$APPS_HOME/etc/profile.d/*` file exists before sourcing. This is due to the fact that Bash, by default, will return the string containing the glob characters if there are no matches for the glob.