### PR TITLE
Enable successful install on macOS 10.12.6

### DIFF
--- a/dotfiles/.bash_dev
+++ b/dotfiles/.bash_dev
@@ -27,6 +27,10 @@ if [[ "$OSTYPE" == 'darwin' && -f "$HOME/.ssh/id_rsa" ]]; then
   ssh-add -A &>/dev/null
 fi
 
+if command -v gpg >/dev/null && [[ -z "$GPG_TTY" ]]; then
+  export GPG_TTY="$(tty)"
+fi
+
 # Creates a branch-specific git working directory in the same parent directory
 # as the original repository.
 git-new-workdir() {

--- a/packages/macos
+++ b/packages/macos
@@ -11,6 +11,8 @@ export PLATFORM_PACKAGES=(
   'xz'
 )
 
+__BREW_INSTALL_URL="https://raw.githubusercontent.com/Homebrew/install/master/install"
+
 platform_pre_install() {
   if [[ ! -d '/Applications/Xcode.app' ]]; then
     echo "Please install Xcode and run this script again."

--- a/scripts/install.d/languages.d/go
+++ b/scripts/install.d/languages.d/go
@@ -11,41 +11,70 @@
 #
 # Will install gvm in `<app-sys-root>/gvm` and add `/etc/profile.d/gvm.sh`.
 
+declare -r _GVM_ROOT="$APPS_HOME/gvm"
+declare -r _GVM_VERSION='34b56311e1e3add4b8f7ce3eeadd23f19c627328'
 declare -r _GVM_PROFILE="$APPS_HOME/etc/profile.d/gvm.sh"
 declare -r _GVM_INSTALLER_URL='https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer'
+declare -r _GVM_BOOTSTRAP_VERSION='release-branch.go1.4'
 
 _install_gvm() {
-  local app_sys_root="$1"
-  local gvm_dir="$app_sys_root/gvm"
-  local gvm_version="$2"
-
   if [[ -f "$_GVM_PROFILE" ]]; then
     return
   fi
 
   curl -L -O "$_GVM_INSTALLER_URL"
-  GVM_NO_UPDATE_PROFILE=true bash ./gvm-installer "$gvm_version" "$app_sys_root"
+  GVM_NO_UPDATE_PROFILE=true bash ./gvm-installer "$_GVM_VERSION" "$APPS_HOME"
   rm ./gvm-installer
-  echo ". '$gvm_dir/scripts/gvm'" >>"$_GVM_PROFILE"
+  echo ". '$_GVM_ROOT/scripts/gvm'" >>"$_GVM_PROFILE"
   chmod +x "$_GVM_PROFILE"
 }
 
-_install_go() {
-  local app_sys_root="$1"
-  local go_version="$2"
-  local gvm_version="$3"
+_prepare_go_repo_for_bootstrap() {
+  local repo_url='https://go.googlesource.com/go'
+  local repo_path="$_GVM_ROOT/archive/go"
+  local version="$_GVM_BOOTSTRAP_VERSION"
+  local orig_pwd="$PWD"
 
-  if [[ -z "$go_version" ]]; then
-    return
+  printf 'Preparing %s to build %s\n' "$repo_path" "$version"
+
+  if [[ ! -d "$repo_path" ]] && ! git clone "$repo_url" "$repo_path"; then
+    printf 'Failed to clone %s into %s\n' "$repo_url" "$repo_path" >&2
+    exit 1
+  elif ! cd "$repo_path" >/dev/null; then
+    printf 'Failed to change into repo directory %s\n' "$repo_path" >&2
+    exit 1
+  elif ! git fetch origin "$version"; then
+    printf 'Failed to fetch bootstrap branch %s\n' "$version" >&2
+    exit 1
+  elif ! git checkout "$version"; then
+    printf 'Failed to checkout bootstrap branch %s\n' "$version" >&2
+    exit 1
+  elif ! cd "$orig_pwd" >/dev/null; then
+    printf 'Failed to change directory back to %s\n' "$orig_pwd" >&2
+    exit 1
   fi
+}
 
-  _install_gvm "$app_sys_root" "$gvm_version"
+_install_go() {
+  _install_gvm
   . "$_GVM_PROFILE"
-  gvm install go1.4.3
-  gvm use go1.4.3
-  gvm install $go_version
-  gvm use $go_version --default
-  gvm uninstall go1.4.3
+
+  if [[ -f "$_GVM_ROOT/gos/$GO_VERSION/bin/go" ]]; then
+    printf 'Go version %s already installed\n' "$GO_VERSION"
+    return
+  elif ! _prepare_go_repo_for_bootstrap; then
+    return 1
+  elif ! gvm install "$_GVM_BOOTSTRAP_VERSION"; then
+    return 1
+  elif ! gvm use "$_GVM_BOOTSTRAP_VERSION"; then
+    return 1
+  elif ! GOROOT_BOOTSTRAP="$_GVM_ROOT/gos/$_GVM_BOOTSTRAP_VERSION" \
+    gvm install "$GO_VERSION"; then
+    return 1
+  elif ! gvm use "$GO_VERSION" --default; then
+    return 1
+  fi
+  gvm uninstall "$_GVM_BOOTSTRAP_VERSION"
 }
 
 _install_go "$@"

--- a/scripts/install.d/languages.d/node
+++ b/scripts/install.d/languages.d/node
@@ -2,9 +2,9 @@
 #
 # Install nvm and the latest Node.js version
 
-declare -r _NVM_ROOT="$APP_SYS_ROOT/nvm"
+declare -r _NVM_ROOT="$APPS_HOME/nvm"
 declare -r _NVM_VERSION='v0.31.0'
-declare -r _NVM_PROFILE='/etc/profile.d/nvm.sh'
+declare -r _NVM_PROFILE="$APPS_HOME/etc/profile.d/nvm.sh"
 
 _install_nvm() {
   local orig_pwd="$PWD"

--- a/scripts/install.d/languages.d/python
+++ b/scripts/install.d/languages.d/python
@@ -2,9 +2,9 @@
 #
 # Install pyenv and the latest Python version
 
-declare -r _PYENV_ROOT="$APP_SYS_ROOT/pyenv"
-declare -r _PYENV_VERSION='v20160202'
-declare -r _PYENV_PROFILE='/etc/profile.d/pyenv.sh'
+declare -r _PYENV_ROOT="$APPS_HOME/pyenv"
+declare -r _PYENV_VERSION='v1.1.3'
+declare -r _PYENV_PROFILE="$APPS_HOME/etc/profile.d/pyenv.sh"
 
 _install_pyenv() {
   local orig_pwd="$PWD"
@@ -26,8 +26,8 @@ _install_pyenv() {
 _install_python() {
   _install_pyenv
   . "$_PYENV_PROFILE"
-  pyenv install $_PYTHON_VERSION
-  pyenv global $_PYTHON_VERSION
+  pyenv install $PYTHON_VERSION
+  pyenv global $PYTHON_VERSION
   pip install --upgrade pip
 }
 

--- a/scripts/install.d/languages.d/ruby
+++ b/scripts/install.d/languages.d/ruby
@@ -2,10 +2,10 @@
 #
 # Install rbenv and the latest Ruby version
 
-declare -r _RBENV_ROOT="$APP_SYS_ROOT/rbenv"
-declare -r _RBENV_VERSION='v1.0.0'
-declare -r _RUBY_BUILD_VERSION='v20160228'
-declare -r _RBENV_PROFILE='/etc/profile.d/rbenv.sh'
+declare -r _RBENV_ROOT="$APPS_HOME/rbenv"
+declare -r _RBENV_VERSION='v1.1.1'
+declare -r _RUBY_BUILD_VERSION='v20170726'
+declare -r _RBENV_PROFILE="$APPS_HOME/etc/profile.d/rbenv.sh"
 
 _install_rbenv() {
   local orig_pwd="$PWD"
@@ -32,8 +32,8 @@ _install_rbenv() {
 _install_ruby() {
   _install_rbenv
   . "$_RBENV_PROFILE"
-  rbenv install "$_RUBY_VERSION"
-  rbenv global "$_RUBY_VERSION"
+  rbenv install "$RUBY_VERSION"
+  rbenv global "$RUBY_VERSION"
   gem install bundler colorator
 }
 

--- a/settings.bash
+++ b/settings.bash
@@ -23,6 +23,7 @@ declare -r PACKAGES_ADD_IF_MISSING=(
   'curl'
   'file'
   'gcc'
+  'gpg'
   'less'
   'make'
   'man'
@@ -46,19 +47,19 @@ declare -r VIM_PATHOGEN_BUNDLE_REPOS=(
 
 NPMS=(
   'livedown'
-  'node-inspector'
   'yo'
 )
+#  'node-inspector'
 
 # Since these may collide with variables from the language managers, they're not
 # readonly.
 # TODO(mbland): Restore GVM_VERSION if/when patch support is merged into
 # moovweb/gvm.
-declare GO_VERSION='go1.7.4'
-declare GVM_VERSION='patches' # 'f38923cc7b3108747b67ff8d0d633569b36cf99b'
+declare GO_VERSION='go1.9'
+#declare GVM_VERSION='patches' # 'f38923cc7b3108747b67ff8d0d633569b36cf99b'
 
-declare -r NODE_VERSION='5.7.1'
+declare -r NODE_VERSION='8.4.0'
 
-declare -r PYTHON_VERSION='3.5.1'
+declare -r PYTHON_VERSION='3.6.2'
 
-declare -r RUBY_VERSION='2.3.0'
+declare -r RUBY_VERSION='2.4.1'


### PR DESCRIPTION
Of particular interest are the updates to `./go install languages go` whereby the Go source repo is primed with the `GOROOT_BOOTSTRAP` version in `_prepare_go_repo_for_bootstrap`. This is necessary due to the macOS Sierra issues described in https://github.com/golang/go/issues/16352. The fix is only in the `release-branch.go1.4` branch not a tag, which causes `gvm` not to find it without this priming step.